### PR TITLE
fixes the imsize argument to imagetable not taking effect

### DIFF
--- a/html4vision/matchCol.js
+++ b/html4vision/matchCol.js
@@ -32,7 +32,7 @@ function matchCol(matchColId, scale) {
 			var row = table.rows[r];
 			var ele = row.cells[matchColId].firstElementChild;
 			if (!ele) continue;
-			if (ele.tagName === "DIV")
+			if (ele.tagName === "A")
 				ele = ele.firstElementChild;
 			if (!ele || ele.tagName !== "IMG") continue;
 			if (ele.complete || ele.naturalWidth > 0) {


### PR DESCRIPTION
The script loops the tags (which are all `<a>`) and thus never reaches the part where it actually resizes the image. With this simple fix the imsize argument (single integer) works for me.