### PR TITLE
Fix bug on windows where drive needs to be removed from thumb filename

### DIFF
--- a/html4vision/thumbs.py
+++ b/html4vision/thumbs.py
@@ -11,7 +11,7 @@ class ThumbnailGenerator:
         self.quality = quality
 
     def make_thumb(self, filename):
-        thumb_filename = os.path.join(self.thumbs_dir, filename.replace(os.sep, '___'))
+        thumb_filename = os.path.join(self.thumbs_dir, os.path.splitdrive(filename)[1].replace(os.sep, '___'))
         thumb_ok = True
         st_filename = os.stat(filename)
         try:


### PR DESCRIPTION
I did not test the thumbnail functionality on Windows previously. This commit fixes a bug in the thumbnail filenames on Windows where the drive (e.g. C:) needs to be removed from the filename, otherwise it results in an odd filename that Windows cannot handle.