### PR TITLE
Add mesh opt decode support for model viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ imagetable(
     # interaction
     overlay_toggle=False, sortable=False,
     # 3d model viewer
-    auto_rotate=False, camera_controls=True,
+    auto_rotate=False, camera_controls=True, mesh_opt=False,
 )
 ```
 The only required argument is `cols`, which is a sequence of `Col` objects, specifying the content of the table. `out_file` optionally names the output file while `title` sets the title of the generated HTML page.
@@ -85,7 +85,7 @@ The meaning and format for other arguments can be found in respective sections
 - [sorting](#sorting): `sortcol`, `sortable`, `sticky_header`, `sort_style`, `zebra`, `summary_row` and `summary_color`.
 - [display toggle](#display-toggle): `overlay_toggle`.
 - [styling through CSS](#styling-through-CSS): `style`.
-- [3d models](#3d-models): `auto_rotate` and `camera_controls`.
+- [3d models](#3d-models): `auto_rotate`, `camera_controls` and `mesh_opt`.
 
 ## Web publishing
 
@@ -214,6 +214,7 @@ Not only does this repo tiles images, but also 3D models! The rendering and cont
     <img alt="3d_model_example" src="examples/model.png" width="500px">
 </p>
 
+For glb meshes optimized with the `EXT_meshopt_compression` extension, enable `mesh_opt=True`. For more details about meshopt, see the [model-viewer meshoptSupport documentation](https://modelviewer.dev/examples/loading/#meshoptSupport).
 
 NOTE: you need to serve the generated HTML with a server to view the content (see [web publishing](#web-publishing)). Directly opening the HTML file locally will yield cross-origin error (CROS).
 

--- a/html4vision/table.py
+++ b/html4vision/table.py
@@ -47,6 +47,7 @@ def imagetable(
         # 3d model viewer
         auto_rotate=False,
         camera_controls=True,
+        mesh_opt=False,
     ):
 
     thumbnail_generators = []
@@ -195,6 +196,11 @@ def imagetable(
             
             if use_model_viewer:
                 model_viewer_opts = {'auto-rotate': auto_rotate, 'camera-controls': camera_controls}
+                if mesh_opt:
+                        script(text("""
+                            self.ModelViewerElement = self.ModelViewerElement || {};
+                            self.ModelViewerElement.meshoptDecoderLocation = 'https://cdn.jsdelivr.net/npm/meshoptimizer/meshopt_decoder.js';
+                        """, escape=False))
                 script(type="module", src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js")
 
             css = '' # custom CSS


### PR DESCRIPTION
Hi,
Thank you for your great work.
I noticing current model viewer configuration doesn't support optmized mesh with MeshOpt. I usually compress large meshes with [gltf-transform](https://gltf-transform.dev/) to accelerate the mesh loading in the html tables.
To fix this issue, we can simply adding some configurations for the modelviewer. Here is the original model viewer reference example for loading mesh with mesh opt: [meshoptSupport](https://modelviewer.dev/examples/loading/#meshoptSupport).

All the best.